### PR TITLE
Change import POSIX::tmpnam to File::Temp::tmpnam().

### DIFF
--- a/IAP/annotateVariants.pm
+++ b/IAP/annotateVariants.pm
@@ -13,8 +13,8 @@
 package IAP::annotateVariants;
 
 use strict;
-use POSIX qw(tmpnam);
-use lib "$FindBin::Bin"; #locates pipeline directory                                                                                                              
+use File::Temp;
+use File::Basename;
 use IAP::sge;
 
 sub runAnnotateVariants {
@@ -153,7 +153,7 @@ sub runAnnotateVariants {
 ############
 sub get_job_id {
     my $id = tmpnam();
-    $id=~s/\/tmp\/file//;
+    $id=basename($id);
     return $id;
 }
 ############

--- a/IAP/baf.pm
+++ b/IAP/baf.pm
@@ -10,8 +10,8 @@
 package IAP::baf;
 
 use strict;
-use POSIX qw(tmpnam);
-use lib "$FindBin::Bin"; #locates pipeline directory
+use File::Temp;
+use File::Basename;
 use IAP::sge;
 
 sub runBAF {
@@ -168,7 +168,7 @@ sub runBAF {
 ############
 sub get_job_id {
     my $id = tmpnam();
-    $id=~s/\/tmp\/file//;
+    $id=basename($id);
     return $id;
 }
 ############

--- a/IAP/baseRecal.pm
+++ b/IAP/baseRecal.pm
@@ -10,8 +10,8 @@
 package IAP::baseRecal;
 
 use strict;
-use POSIX qw(tmpnam);
-use lib "$FindBin::Bin"; #locates pipeline directory
+use File::Temp;
+use File::Basename;
 use IAP::sge;
 
 sub runBaseRecalibration {
@@ -144,8 +144,8 @@ sub runBaseRecalibration {
 
 ############
 sub get_job_id {
-   my $id = tmpnam(); 
-      $id=~s/\/tmp\/file//;
+   my $id = tmpnam();
+      $id=basename($id);
    return $id;
 }
 ############ 

--- a/IAP/callableLoci.pm
+++ b/IAP/callableLoci.pm
@@ -10,8 +10,8 @@
 package IAP::callableLoci;
 
 use strict;
-use POSIX qw(tmpnam);
-use lib "$FindBin::Bin"; #locates pipeline directory
+use File::Temp;
+use File::Basename;
 use IAP::sge;
 
 sub runCallableLoci {
@@ -109,7 +109,7 @@ sub runCallableLoci {
 ############
 sub get_job_id {
     my $id = tmpnam();
-    $id=~s/\/tmp\/file//;
+    $id=basename($id);
     return $id;
 }
 ############

--- a/IAP/calling.pm
+++ b/IAP/calling.pm
@@ -13,8 +13,8 @@
 package IAP::calling;
 
 use strict;
-use POSIX qw(tmpnam);
-use lib "$FindBin::Bin"; #locates pipeline directory
+use File::Temp;
+use File::Basename;
 use IAP::sge;
 
 sub runVariantCalling {
@@ -236,7 +236,7 @@ sub runVcfPrep {
 ############
 sub get_job_id {
     my $id = tmpnam();
-    $id=~s/\/tmp\/file//;
+    $id=basename($id);
     return $id;
 }
 ############

--- a/IAP/check.pm
+++ b/IAP/check.pm
@@ -10,9 +10,9 @@
 package IAP::check;
 
 use strict;
-use POSIX qw(tmpnam);
+use File::Temp;
+use File::Basename;
 use FindBin;
-use lib "$FindBin::Bin"; #locates pipeline directory
 use IAP::sge;
 
 sub runCheck {
@@ -366,7 +366,7 @@ sub runCheck {
 ############
 sub get_job_id {
     my $id = tmpnam();
-    $id=~s/\/tmp\/file//;
+    $id=basename($id);
     return $id;
 }
 ############

--- a/IAP/copyNumber.pm
+++ b/IAP/copyNumber.pm
@@ -12,9 +12,9 @@
 package IAP::copyNumber;
 
 use strict;
-use POSIX qw(tmpnam);
+use File::Temp;
+use File::Basename;
 use File::Path qw(make_path);
-use lib "$FindBin::Bin"; #locates pipeline directory
 use IAP::sge;
 
 sub runCopyNumberTools {
@@ -436,7 +436,7 @@ sub runContraVisualization {
 ############
 sub get_job_id {
     my $id = tmpnam();
-    $id=~s/\/tmp\/file//;
+    $id=basename($id);
     return $id;
 }
 ############

--- a/IAP/filterVariants.pm
+++ b/IAP/filterVariants.pm
@@ -11,8 +11,8 @@
 package IAP::filterVariants;
 
 use strict;
-use POSIX qw(tmpnam);
-use lib "$FindBin::Bin"; #locates pipeline directory                                                                                                              
+use File::Temp;
+use File::Basename;
 use IAP::sge;
 
 sub runFilterVariants {
@@ -149,7 +149,7 @@ sub runFilterVariants {
 ############
 sub get_job_id {
     my $id = tmpnam();
-    $id=~s/\/tmp\/file//;
+    $id=basename($id);
     return $id;
 }
 ############

--- a/IAP/mapping.pm
+++ b/IAP/mapping.pm
@@ -13,8 +13,8 @@
 package IAP::mapping;
 
 use strict;
-use POSIX qw(tmpnam);
-use lib "$FindBin::Bin"; #locates pipeline directory
+use File::Temp;
+use File::Basename;
 use IAP::sge;
 
 sub runMapping {
@@ -549,7 +549,7 @@ sub runBamPrep {
 ############
 sub get_job_id {
    my $id = tmpnam();
-      $id=~s/\/tmp\/file//;
+   $id=basename($id);
    return $id;
 }
 ############

--- a/IAP/nipt.pm
+++ b/IAP/nipt.pm
@@ -11,9 +11,9 @@
 package IAP::nipt;
 
 use strict;
-use POSIX qw(tmpnam);
+use File::Temp;
+use File::Basename;
 use FindBin;
-use lib "$FindBin::Bin"; #locates pipeline directory
 use IAP::sge;
 
 
@@ -82,8 +82,8 @@ sub runNipt {
 
 ############
 sub get_job_id {
-   my $id = tmpnam(); 
-      $id=~s/\/tmp\/file//;
+   my $id = tmpnam();
+   $id=basename($id);
    return $id;
 }
 

--- a/IAP/poststats.pm
+++ b/IAP/poststats.pm
@@ -11,7 +11,8 @@
 package IAP::poststats;
 
 use strict;
-use POSIX qw(tmpnam);
+use File::Temp;
+use File::Basename;
 use FindBin;
 use IAP::sge;
 
@@ -120,8 +121,8 @@ sub runPostStats {
 
 ############
 sub get_job_id {
-   my $id = tmpnam(); 
-      $id=~s/\/tmp\/file//;
+   my $id = tmpnam();
+   $id=basename($id);
    return $id;
 }
 

--- a/IAP/prestats.pm
+++ b/IAP/prestats.pm
@@ -10,8 +10,8 @@
 package IAP::prestats;
 
 use strict;
-use POSIX qw(tmpnam);
-use lib "$FindBin::Bin"; #locates pipeline directory
+use File::Temp;
+use File::Basename;
 use IAP::sge;
 
 sub runPreStats {
@@ -60,7 +60,7 @@ sub runPreStats {
 ############
 sub get_job_id {
    my $id = tmpnam(); 
-      $id=~s/\/tmp\/file//;
+   $id=basename($id);
    return $id;
 }
 ############

--- a/IAP/realign.pm
+++ b/IAP/realign.pm
@@ -11,8 +11,8 @@
 package IAP::realign;
 
 use strict;
-use POSIX qw(tmpnam);
-use lib "$FindBin::Bin"; #locates pipeline directory
+use File::Temp;
+use File::Basename;
 use IAP::sge;
 
 sub runRealignment {
@@ -261,8 +261,8 @@ sub runRealignment {
 
 ############
 sub get_job_id {
-   my $id = tmpnam(); 
-      $id=~s/\/tmp\/file//;
+   my $id = tmpnam();
+   $id=basename($id);
    return $id;
 }
 ############

--- a/IAP/somaticVariants.pm
+++ b/IAP/somaticVariants.pm
@@ -12,9 +12,9 @@
 package IAP::somaticVariants;
 
 use strict;
-use POSIX qw(tmpnam);
+use File::Temp;
+use File::Basename;
 use File::Path qw(make_path);
-use lib "$FindBin::Bin"; #locates pipeline directory
 use IAP::sge;
 
 ### Run and merge
@@ -729,7 +729,7 @@ sub runMutect {
 ############
 sub get_job_id {
     my $id = tmpnam();
-    $id=~s/\/tmp\/file//;
+    $id=basename($id);
     return $id;
 }
 

--- a/IAP/structuralVariants.pm
+++ b/IAP/structuralVariants.pm
@@ -10,9 +10,9 @@
 package IAP::structuralVariants;
 
 use strict;
-use POSIX qw(tmpnam);
+use File::Temp;
+use File::Basename;
 use File::Path qw(make_path);
-use lib "$FindBin::Bin"; #locates pipeline directory
 use IAP::sge;
 
 sub runStructuralVariantCallers {
@@ -514,7 +514,7 @@ sub get_chrs_from_dict {
 ############
 sub get_job_id {
     my $id = tmpnam();
-    $id=~s/\/tmp\/file//;
+    $id=basename($id);
     return $id;
 }
 ############

--- a/IAP/vcfutils.pm
+++ b/IAP/vcfutils.pm
@@ -14,8 +14,8 @@
 package IAP::vcfutils;
 
 use strict;
-use POSIX qw(tmpnam);
-use lib "$FindBin::Bin"; #locates pipeline directory
+use File::Temp;
+use File::Basename;
 use IAP::sge;
 
 
@@ -199,7 +199,7 @@ sub runVcfUtils {
 ############
 sub get_job_id {
     my $id = tmpnam();
-    $id=~s/\/tmp\/file//;
+    $id=basename($id);
     return $id;
 }
 ############

--- a/illumina_pipeline.pl
+++ b/illumina_pipeline.pl
@@ -10,16 +10,16 @@
 
 ### Load common perl modules ####
 use strict;
-use POSIX qw(tmpnam strftime);
+use File::Temp;
+use POSIX qw(strftime);
 use Getopt::Long;
 use FindBin;
 use File::Path qw(make_path);
 use File::Copy qw(copy);
 use Cwd qw( abs_path );
-use File::Basename qw( dirname );
+use File::Basename qw( dirname basename );
 
 ### Load pipeline modules ####
-use lib "$FindBin::Bin"; #locates pipeline directory
 use IAP::prestats;
 use IAP::mapping;
 use IAP::poststats;

--- a/scripts/run_SAp42ann_on_vcf.pl
+++ b/scripts/run_SAp42ann_on_vcf.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 use strict;
-use POSIX qw(tmpnam);
+use File::Temp;
 
 
 my $email = "i.nijman\@umcutrecht.nl";


### PR DESCRIPTION
* IAP/annotateVariants.pm: Use basename() instead of the regexp.
* IAP/baf.pm: Likewise.
* IAP/baseRecal.pm: Likewise.
* IAP/callableLoci.pm: Likewise.
* IAP/calling.pm: Likewise.
* IAP/check.pm: Likewise.
* IAP/copyNumber.pm: Likewise.
* IAP/filterVariants.pm: Likewise.
* IAP/mapping.pm: Likewise.
* IAP/nipt.pm: Likewise.
* IAP/poststats.pm: Likewise.
* IAP/prestats.pm: Likewise.
* IAP/realign.pm: Likewise.
* IAP/somaticVariants.pm: Likewise.
* IAP/structuralVariants.pm: Likewise.
* IAP/vcfutils.pm: Likewise.
* illumina_pipeline.pl: Change import for tmpnam();
* scripts/run_SAp42ann_on_vcf.pl: Likewise.