### PR TITLE
Small fix to BAF plot

### DIFF
--- a/scripts/makeBAFplot.R
+++ b/scripts/makeBAFplot.R
@@ -64,7 +64,7 @@ for (i in c(1:length(chromosomes))) {
   tmp <- subset(rowdat, CHROM==chrom)
 
   for (j in seq(1, nrow(tmp), by=binsize/2)) {
-    maxy <- j+binsize
+    maxy <- j+binsize-1
 
     if (maxy>nrow(tmp)) {maxy<-nrow(tmp)}
 


### PR DESCRIPTION
Made a small fix to the indexing of the bins for the BAF plot. The bins were too large, because R indexing is inclusive. The too large bins resulted in some variants being present in three bins.